### PR TITLE
#164489933 Pagination support for ratings

### DIFF
--- a/test/7-rate.test.js
+++ b/test/7-rate.test.js
@@ -90,6 +90,33 @@ describe('Article ratings and reading stats', () => {
           done();
         });
     });
+
+    it('Should return all article ratings on a single page', (done) => {
+      chai.request(app)
+        .get(`/api/articles/${articleId}/rate?page=1`)
+        .end((err, res) => {
+          if (err) done(err);
+          res.should.have.status(200);
+          res.body.should.be.an('object');
+          res.body.should.have.property('ratings');
+          res.body.ratings.should.be.an('array');
+          done();
+        });
+    });
+
+    it('Should return all article ratings on a single page with specified limit', (done) => {
+      chai.request(app)
+        .get(`/api/articles/${articleId}/rate?page=1&limit=1`)
+        .end((err, res) => {
+          if (err) done(err);
+          res.should.have.status(200);
+          res.body.should.be.an('object');
+          res.body.should.have.property('ratings');
+          res.body.ratings.should.be.an('array');
+          done();
+        });
+    });
+
     it('Should send article rating for update user rating to an article', (done) => {
       rates.rating = 2;
       chai.request(app)

--- a/testingdata/user.json
+++ b/testingdata/user.json
@@ -49,7 +49,7 @@
     "password": "1Kig1L@20"
   },
   "googleValidToken": {
-    "access_token": "ya29.Glv3BlNvsRU4OoS-KhPEGyhErACH7v7fsrahYoJOw0MSbjk0IqRpuzsTIKcmLKzRWWXtZQOerh2ftRZ4wJf4RxdXIBRZwt3yZelCm3BwQk7slEHJeuV9WrhYSWh4"
+    "access_token": "ya29.Glz3Bsq5JmrrYrZAd5HPIISEwE1tR4iYaG8MPPPkw-UXmf5bRVcGSLIlznsjJpmzuWxF2vtW9GKGX9IUqGiHFW5uTuB_O9jn9UKvPHq6VDi_4Em7vKapQo1QooZ2kA"
   },
   "googleInvalidToken": {
     "access_token": "ya29.Glv1Bvx5U-OTtL7Qxym4ugGyyRsxhEPoKe_Uz5cKKF_mLuGzrxHywvzLx_kgWKVfHZTKL2eg0K5oJ7RVKXwqDSG5-f5PUlo0iFz5jISJrVWsc5Ls7crApI-Uagjy"


### PR DESCRIPTION
**What does this PR do?**

This PR ensures that there is pagination on article ratings.

**Description of Task to be completed?**

This PR adds query params to allow pagination support for article ratings.

**How should this be manually tested?**

- go to postman and type `http://localhost:3000/api/articles/:id/rate?page=1` with the id of an article, then send a GET request to get all ratings
- if you have more than 20 ratings on that article you will get only 20

**What are the relevant pivotal tracker stories?**

[#164489933](https://www.pivotaltracker.com/story/show/164489933)

**Screenshot**

Response

<img width="634" alt="Screen Shot 2019-04-26 at 12 15 39" src="https://user-images.githubusercontent.com/32579116/56801727-7ef7fe00-681e-11e9-9073-696b380c8c1d.png">


